### PR TITLE
fix theme name so hugo builds

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,6 +1,6 @@
 baseURL = "example.com"
 title = "Manis"
-theme = "manis"
+theme = "manis-hugo-theme"
 
 # Copyright notice. Note: You can use HTML tag here
 copyright = "&copy; 2019 Yurizal Susanto"


### PR DESCRIPTION
Following your guide to copy exampleSite config.toml leads to this error

```
Error: module "manis" not found; either add it as a Hugo Module or store it in "/Users/tobiasmcvey/projects/blogmanis/themes".: module does not exist
```

Just need to fix the theme name in the exampleSite config.toml file

from
```toml
theme="manis"
```
to
```toml
theme = "manis-hugo-theme"
```
and Hugo builds :)

Great looking theme btw