### PR TITLE
Replace the deprecated Hugo variable

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,7 +1,7 @@
 	<head>
 		<meta charset="utf-8"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		{{ .Hugo.Generator }}
+		{{ hugo.Generator }}
 		{{ partial "metatitle" . }}
 		{{ partial "metadesc" . }}
 


### PR DESCRIPTION
## Problem

`Page.Hugo` variable was already deprecated. Hugo gave warning `Page.Hugo is deprecated and will be removed in a future release. Use the global hugo function.` when it ran every time.

## Solution

Replace `.Hugo` with `hugo` as the message suggested. Also see https://gohugo.io/variables/hugo/#readout for details.