### PR TITLE
[Fix] Fix broken dark mode in Firefox (#23)

### DIFF
--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -1,8 +1,8 @@
 html {
-    background-color: #ebebeb !important;
+    background-color: #141414 !important;
 }
 
-html {
+body {
 filter: invert(100%) hue-rotate(180deg);
 }
 


### PR DESCRIPTION
Following the advice from a [Stack Overflow answer](https://stackoverflow.com/questions/61246462/css-filterinvert-not-working-with-background-color) on this issue, I put the background in `html` and the css filter in `body`, which seems to fix the problem.

