### PR TITLE
fix: use .OutputFormats.Get "rss"

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,13 +1,21 @@
 {{ with .Site.Params.Email }}
-<a href="mailto:{{.}}"><img class="icon-social" src="/img/email.svg" alt="Email Me!"/></a>
-{{ end }}
-{{ with .Site.Params.Github }}
-<a href="{{.}}"><img class="icon-social" src="/img/github.svg" alt="Github"/></a>
-{{ end }}
-{{ with .Site.Params.Twitter }}
-<a href="{{.}}"><img class="icon-social" src="/img/twitter.svg" alt="Twitter"/></a>
-{{ end }}
-<a href="{{.Site.RSSLink}}" target="_blank"><img class="icon-social" src="/img/feed.svg" alt="Feed"></a>
-{{ with .Site.Params.Twitch}}
-<a href="{{.}}"><img class="icon-social" src="/img/twitch.svg" alt="Twitch"/></a>
+<a href="mailto:{{.}}"
+  ><img class="icon-social" src="/img/email.svg" alt="Email Me!"
+/></a>
+{{ end }} {{ with .Site.Params.Github }}
+<a href="{{.}}"
+  ><img class="icon-social" src="/img/github.svg" alt="Github"
+/></a>
+{{ end }} {{ with .Site.Params.Twitter }}
+<a href="{{.}}"
+  ><img class="icon-social" src="/img/twitter.svg" alt="Twitter"
+/></a>
+{{ end }} {{ with .OutputFormats.Get "rss" -}}
+<a href="{{.Permalink}}" target="_blank"
+  ><img class="icon-social" src="/img/feed.svg" alt="Feed"
+/></a>
+{{ end }} {{ with .Site.Params.Twitch}}
+<a href="{{.}}"
+  ><img class="icon-social" src="/img/twitch.svg" alt="Twitch"
+/></a>
 {{ end }}


### PR DESCRIPTION
The old way of getting RSS link now fails on new hugo:

```
ERROR deprecated: .Site.RSSLink was deprecated in Hugo v0.114.0 and will be removed in Hugo 0.127.0. Use the Output Format's Permalink method instead, e.g. .OutputFormats.Get "RSS".Permalink
```